### PR TITLE
dsl-tester: s3 A(Alias) record format error

### DIFF
--- a/lib/roadworker/dsl-tester.rb
+++ b/lib/roadworker/dsl-tester.rb
@@ -134,7 +134,7 @@ module Roadworker
                     false
                   end
                 }
-              when /\As3-website-(?:[^.]+)\.amazonaws\.com\z/
+              when /\As3-website-(?:[^.]+)\.amazonaws\.com\.\z/
                 response_answer_ip_1_2 = response.answer.map {|a| a.value.split('.').slice(0, 2) }.uniq
 
                 # try 3 times


### PR DESCRIPTION
Missing `.` at the end of the URL.

See more:
https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-values-alias.html

Signed-off-by: Gergő Nagy <contact@gergonagy.com>