### PR TITLE
dsl-tester: A(Alias) fake diff fixed

### DIFF
--- a/lib/roadworker/dsl-tester.rb
+++ b/lib/roadworker/dsl-tester.rb
@@ -118,11 +118,13 @@ module Roadworker
             log(:debug, "  #{logmsg_expected}\n  #{logmsg_actual}", :white)
 
             is_same = false
+            check_ttl = true
 
             if fetch_dns_name(record.dns_name)
               # A(Alias)
               case fetch_dns_name(record.dns_name).sub(/\.\z/, '')
               when /\.elb\.amazonaws\.com/i
+                check_ttl = false
                 is_same = response.answer.all? {|a|
                   response_query_ptr = query(a.value, 'PTR', error_messages)
 
@@ -135,6 +137,7 @@ module Roadworker
                   end
                 }
               when /\As3-website-(?:[^.]+)\.amazonaws\.com\z/
+                check_ttl = false
                 response_answer_ip_1_2 = response.answer.map {|a| a.value.split('.').slice(0, 2) }.uniq
 
                 # try 3 times
@@ -152,6 +155,7 @@ module Roadworker
                   }
                 end
               when /\.cloudfront\.net\z/
+                check_ttl = false
                 is_same = response.answer.all? {|a|
                   response_query_ptr = query(a.value, 'PTR', error_messages)
 
@@ -176,7 +180,7 @@ module Roadworker
               is_same = (expected_value == actual_value)
             end
 
-            if is_same
+            if is_same && check_ttl
               unless actual_ttls.all? {|i| i <= expected_ttl }
                 is_same = false
               end


### PR DESCRIPTION
Thanks to the non-standard Alias record type that has been introduced by
AWS Route 53 one could get fake diffs while running `--test`.
This had no effect on the actual `--apply` command since nothing would
change but could mislead the user that the record is going to be updated.

The root cause is the lack of the actual TTL field on the Alias records so
when the `dsl-tester` tried to check if the actual and expected values
match it showed that they are different.

Since the A (ipv4) record (returned by the query) has TTL and the Alias has not.

Solution:

I've introduced a `check_ttl` variable that sets if the TTL values
should be checked or not. The code simply disables ttl check if it's an
Alias record.

Signed-off-by: Gergő Nagy <contact@gergonagy.com>